### PR TITLE
Fix export issues across platforms

### DIFF
--- a/src/panels/menu/modal/export/ExportTermsCSV.ts
+++ b/src/panels/menu/modal/export/ExportTermsCSV.ts
@@ -23,8 +23,8 @@ import { Locale } from "../../../../config/Locale";
 
 export async function exportTermsCSV(
   exportLanguage: string
-): Promise<[source: string, error: string]> {
-  const fileID = "data:text/csv;charset=utf-8,";
+): Promise<[source: Blob, error: string]> {
+  const fileID = "data:text/csv;charset=utf-8";
   const carriageReturn = "\r\n";
   const diagramTerms = Object.keys(WorkspaceElements)
     .filter(
@@ -39,7 +39,10 @@ export async function exportTermsCSV(
     )
     .sort();
   if (diagramTerms.length === 0)
-    return ["", Locale[AppSettings.interfaceLanguage].listExportErrorNoTerms];
+    return [
+      new Blob(),
+      Locale[AppSettings.interfaceLanguage].listExportErrorNoTerms,
+    ];
   const query = [
     "PREFIX dct: <http://purl.org/dc/terms/>",
     "select ?term ?source where {",
@@ -79,7 +82,7 @@ export async function exportTermsCSV(
     console.warn("None of the terms from this diagram have a dct:source.");
   if ("error" in result)
     return [
-      "",
+      new Blob(),
       Locale[AppSettings.interfaceLanguage].listExportErrorNoConnection,
     ];
   const rowDescriptionRow =
@@ -93,7 +96,6 @@ export async function exportTermsCSV(
       "Typ",
     ]) + carriageReturn;
   const source =
-    fileID +
     rowDescriptionRow +
     diagramTerms
       .map((term) => {
@@ -165,5 +167,5 @@ export async function exportTermsCSV(
         );
       })
       .join(carriageReturn);
-  return [source, ""];
+  return [new Blob([source], { type: fileID }), ""];
 }

--- a/src/panels/menu/modal/export/ExportTermsText.ts
+++ b/src/panels/menu/modal/export/ExportTermsText.ts
@@ -17,8 +17,8 @@ import {
 
 export async function exportTermsText(
   exportLanguage: string
-): Promise<[source: string, error: string]> {
-  const fileID = "data:text/plain;charset=utf-8,";
+): Promise<[source: Blob, error: string]> {
+  const fileID = "data:text/plain;charset=utf-8";
   const carriageReturn = "\r\n";
   const diagramTerms = Object.keys(WorkspaceElements)
     .filter(
@@ -28,40 +28,38 @@ export async function exportTermsText(
         isElementVisible(WorkspaceTerms[iri].types, Representation.COMPACT)
     )
     .sort();
-  const source =
-    fileID +
-    diagramTerms
-      .map((term) => {
-        const termName =
-          "- " +
-          getLabelOrBlank(WorkspaceTerms[term].labels, exportLanguage) +
-          carriageReturn;
-        const tropes = getIntrinsicTropeTypeIDs(term)
-          .map(
-            (trope) =>
-              "\t - " +
-              getLabelOrBlank(WorkspaceTerms[trope].labels, exportLanguage)
-          )
-          .join(carriageReturn);
-        const relationships = getActiveToConnections(term)
-          .filter((link) => WorkspaceLinks[link].iri in WorkspaceTerms)
-          .map(
-            (link) =>
-              "\t - " +
-              getLabelOrBlank(
-                WorkspaceTerms[WorkspaceLinks[link].iri].labels,
-                exportLanguage
-              )
-          )
-          .join(carriageReturn);
-        return (
-          termName +
-          tropes +
-          (tropes && relationships ? carriageReturn : "") +
-          relationships +
-          (tropes !== relationships ? carriageReturn : "")
-        );
-      })
-      .join(carriageReturn);
-  return [source, ""];
+  const source = diagramTerms
+    .map((term) => {
+      const termName =
+        "- " +
+        getLabelOrBlank(WorkspaceTerms[term].labels, exportLanguage) +
+        carriageReturn;
+      const tropes = getIntrinsicTropeTypeIDs(term)
+        .map(
+          (trope) =>
+            "\t - " +
+            getLabelOrBlank(WorkspaceTerms[trope].labels, exportLanguage)
+        )
+        .join(carriageReturn);
+      const relationships = getActiveToConnections(term)
+        .filter((link) => WorkspaceLinks[link].iri in WorkspaceTerms)
+        .map(
+          (link) =>
+            "\t - " +
+            getLabelOrBlank(
+              WorkspaceTerms[WorkspaceLinks[link].iri].labels,
+              exportLanguage
+            )
+        )
+        .join(carriageReturn);
+      return (
+        termName +
+        tropes +
+        (tropes && relationships ? carriageReturn : "") +
+        relationships +
+        (tropes !== relationships ? carriageReturn : "")
+      );
+    })
+    .join(carriageReturn);
+  return [new Blob([source], { type: fileID }), ""];
 }


### PR DESCRIPTION
* Fixes issue where Linux platforms 
    - wouldn't assign filename extensions to downloads,
    - had exports with unseparated lists due to incompatible carriage return symbols between Windows and Linux. 

